### PR TITLE
[#168073889] Mentor accept/reject session 

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,7 +7,7 @@ import sessionRoutes from './server/routes/sessionRoutes';
 import AdminRoutes from './server/routes/adminRoutes';
 
 const app = express();
-const port = process.env.PORT || 5000;
+const port = process.env.PORT;
 
 dotenv.config();
 

--- a/server/controllers/session.js
+++ b/server/controllers/session.js
@@ -25,5 +25,29 @@ class Sessions {
       return response.catchError(500, e.message, res);
     }
   }
+
+  static async chooseSession(req, res) {
+    try {
+      const { sessionId } = req.params;
+      const decoded = decoder.decodeToken(req.headers.authorization);
+      const { userId } = decoded;
+
+      const sessionExist = await SessionModel.wasRequested(sessionId, userId);
+      // console.log(sessionExist);
+      if (!sessionExist) {
+        return response.handleError(404, 'You have no requested session with that ID', res);
+      }
+      if (/accept/.test(req.url)) {
+        const accepted = await SessionModel.acceptSession(sessionExist);
+        return response.success(200, accepted, res);
+      }
+      if (/reject/.test(req.url)) {
+        const rejected = await SessionModel.rejectSession(sessionExist);
+        return response.success(200, rejected, res);
+      }
+    } catch (e) {
+      return response.catchError(500, e.message, res);
+    }
+  }
 }
 export default Sessions;

--- a/server/db/mentor.js
+++ b/server/db/mentor.js
@@ -1,4 +1,17 @@
 const mentors = [
+  // {
+  //   userId: 1,
+  //   firstName: 'Im',
+  //   lastName: 'Admin',
+  //   email: 'johndoe1@email.com',
+  //   password: '$2b$10$aVL6hs6.I5z11JJLDHIu2eaZZsod54V465LM7qe8LBuiGFy123jbO',
+  //   address: 'Nairobi Kenya',
+  //   bio: 'rapper, record producer, and actor who was known as one of the most-controversial and best-selling artists of the early 21st century',
+  //   occupation: 'Musician',
+  //   expertise: 'rapping',
+  //   isMentor: true,
+  //   isAdmin: true,
+  // },
   {
     userId: 2,
     firstName: 'ImA',

--- a/server/helpers/responses.js
+++ b/server/helpers/responses.js
@@ -7,13 +7,13 @@ class Responses {
     });
   }
 
-  static handleSuccess(statusCode, message, data, res) {
-    res.status(statusCode).json({
-      status: statusCode,
-      message,
-      data,
-    });
-  }
+  // static handleSuccess(statusCode, message, data, res) {
+  //   res.status(statusCode).json({
+  //     status: statusCode,
+  //     message,
+  //     data,
+  //   });
+  // }
 
   static success(statusCode, message, res) {
     res.status(statusCode).json({

--- a/server/middleware/mentor.js
+++ b/server/middleware/mentor.js
@@ -1,0 +1,12 @@
+import response from '../helpers/responses';
+
+function Mentor(req, res, next) {
+  // console.log(req.locals.isAdmin);
+  if (!req.locals.isMentor) {
+    return response.handleError(403, 'ACCESS DENIED! Not a Mentor', res);
+  }
+  next();
+}
+
+
+export default Mentor;

--- a/server/models/sessionModel.js
+++ b/server/models/sessionModel.js
@@ -10,7 +10,7 @@ class SessionModel {
     this.status = 'pending';
   }
 
-  requestSession() {
+  async requestSession() {
     const session = {
       sessionId: this.sessionId,
       mentorId: this.mentorId,
@@ -26,6 +26,48 @@ class SessionModel {
       return session;
     }
     return false;
+  }
+
+  static async findById(sessionId) {
+    const obj = db.find((o) => o.sessionId === parseInt(sessionId));
+    if (!obj) {
+      return false;
+    }
+    return obj;
+  }
+
+  static async wasRequested(sessionId, mentorId) {
+    const obj = db.find((o) => o.sessionId === parseInt(sessionId) && o.mentorId === parseInt(mentorId));
+    if (!obj) {
+      return false;
+    }
+    return obj;
+  }
+
+  static async acceptSession(session) {
+    const accepted = {
+      sessionId: session.sessionId,
+      mentorId: session.mentorId,
+      menteeId: session.menteeId,
+      questions: session.questions,
+      menteeEmail: session.menteeEmail,
+      status: 'accepted',
+    };
+    db.splice(session.sessionId - 1, 1, accepted);
+    return accepted;
+  }
+
+  static async rejectSession(session) {
+    const rejected = {
+      sessionId: session.sessionId,
+      mentorId: session.mentorId,
+      menteeId: session.menteeId,
+      questions: session.questions,
+      menteeEmail: session.menteeEmail,
+      status: 'rejected',
+    };
+    db.splice(session.sessionId - 1, 1, rejected);
+    return rejected;
   }
 }
 export default SessionModel;

--- a/server/routes/sessionRoutes.js
+++ b/server/routes/sessionRoutes.js
@@ -2,11 +2,14 @@ import express from 'express';
 import Sessions from '../controllers/session';
 import Validations from '../middleware/sessionValidation';
 import authToken from '../middleware/authToken';
+import Mentor from '../middleware/mentor';
 
 
 const router = express.Router();
 
 router.post('/sessions', authToken, Validations.validateSessions, Sessions.requestSession);
+router.patch('/sessions/:sessionId/accept', [authToken, Mentor], Sessions.chooseSession);
+router.patch('/sessions/:sessionId/reject', [authToken, Mentor], Sessions.chooseSession);
 
 
 export default router;

--- a/server/tests/session.test.js
+++ b/server/tests/session.test.js
@@ -74,7 +74,7 @@ describe('SESSION', () => {
         .post('/api/v1/sessions')
         .set('authorization', `Bearer ${userToken}`)
         .send({
-          mentorId: 1,
+          mentorId: 2,
           questions: 'I wanna be a dj,Help?',
         })
         .end((err, res) => {
@@ -120,7 +120,7 @@ describe('SESSION', () => {
     it('should unsuccessfully request a session without token', (done) => {
       chai.request(app)
         .post('/api/v1/sessions')
-        .set('authorization', ` `)
+        .set('authorization', ' ')
         .send({
           mentorId: 2,
           questions: 'I wanna be a dj,Help?',
@@ -153,13 +153,14 @@ describe('SESSION', () => {
     it('should unsuccessfully request a session invalid questions', (done) => {
       chai.request(app)
         .post('/api/v1/sessions')
-        .set('authorization', `Bearer ${userToken}`)
+        .set('authorization', `Bearer ${mentorToken}`)
         .send({
-          mentorId: 'ab',
+          mentorId: 1,
           questions: ' ',
         })
         .end((err, res) => {
           res.should.have.status(400);
+          expect(res.body.error).equals('Question is a required field with a maximum number of 100 chars');
           expect(res).to.be.an('object');
           if (err) return done();
           done();
@@ -171,7 +172,7 @@ describe('SESSION', () => {
         .post('/api/v1/sessions')
         .set('authorization', `Bearer ${userToken}`)
         .send({
-          mentorId: 1,
+          mentorId: 2,
           questions: 'I wanna be a dj,Help?',
         })
         .end((err, res) => {
@@ -184,13 +185,13 @@ describe('SESSION', () => {
     });
   });
 
-  describe('PATCH accept session',()=>{
+  describe('PATCH accept session', () => {
     it('should successfully accept a session', (done) => {
       chai.request(app)
-        .patch('/api/v1/sessions/:sessionId/accept')
+        .patch('/api/v1/sessions/1/accept')
         .set('authorization', `Bearer ${mentorToken}`)
         .end((err, res) => {
-          res.should.have.status(201);
+          res.should.have.status(200);
           expect(res.body.data.status).equals('accepted');
           expect(res).to.be.an('object');
           if (err) return done();
@@ -200,11 +201,11 @@ describe('SESSION', () => {
 
     it('should unsuccessfully accept a session if token is user', (done) => {
       chai.request(app)
-        .patch('/api/v1/sessions/:sessionId/accept')
+        .patch('/api/v1/sessions/1/accept')
         .set('authorization', `Bearer ${userToken}`)
         .end((err, res) => {
           res.should.have.status(403);
-          expect(res.body.data.error).equals('not a mentor');
+          expect(res.body.error).equals('ACCESS DENIED! Not a Mentor');
           expect(res).to.be.an('object');
           if (err) return done();
           done();
@@ -213,8 +214,8 @@ describe('SESSION', () => {
 
     it('should unsuccessfully accept a session if no token provided', (done) => {
       chai.request(app)
-        .patch('/api/v1/sessions/:sessionId/accept')
-        .set('authorization', ` `)
+        .patch('/api/v1/sessions/1/accept')
+        .set('authorization', ' ')
         .end((err, res) => {
           res.should.have.status(401);
           expect(res).to.be.an('object');
@@ -222,15 +223,15 @@ describe('SESSION', () => {
           done();
         });
     });
-  })
+  });
 
-  describe('PATCH reject session',()=>{
+  describe('PATCH reject session', () => {
     it('should successfully accept a session', (done) => {
       chai.request(app)
-        .patch('/api/v1/sessions/:sessionId/reject')
+        .patch('/api/v1/sessions/1/reject')
         .set('authorization', `Bearer ${mentorToken}`)
         .end((err, res) => {
-          res.should.have.status(201);
+          res.should.have.status(200);
           expect(res.body.data.status).equals('rejected');
           expect(res).to.be.an('object');
           if (err) return done();
@@ -240,11 +241,11 @@ describe('SESSION', () => {
 
     it('should unsuccessfully accept a session if token is user', (done) => {
       chai.request(app)
-        .patch('/api/v1/sessions/:sessionId/reject')
+        .patch('/api/v1/sessions/1/reject')
         .set('authorization', `Bearer ${userToken}`)
         .end((err, res) => {
           res.should.have.status(403);
-          expect(res.body.data.error).equals('not a mentor');
+          expect(res.body.error).equals('ACCESS DENIED! Not a Mentor');
           expect(res).to.be.an('object');
           if (err) return done();
           done();
@@ -253,8 +254,8 @@ describe('SESSION', () => {
 
     it('should unsuccessfully accept a session if no token provided', (done) => {
       chai.request(app)
-        .patch('/api/v1/sessions/:sessionId/reject')
-        .set('authorization', ` `)
+        .patch('/api/v1/sessions/1/reject')
+        .set('authorization', ' ')
         .end((err, res) => {
           res.should.have.status(401);
           expect(res).to.be.an('object');
@@ -262,5 +263,5 @@ describe('SESSION', () => {
           done();
         });
     });
-  })
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
Allows a mentor to accept or reject a session
#### Description of Task to be completed?
* User should be able to accept or deny based on the url
* Tests should pass
* Refractor tests
#### How should this be manually tested?
* Clone this  repository https://github.com/BurnerB/FreeMentors-V2.git and cd into FreeMentors-V2
* checkout to branch ft-mentor-accept/reject-session-168073889
* Run npm --init to install all dependancies.
* Run command npm test on your terminal
* Tests should pass
* Open postman and PATCH `/sessions/:sessionId/accept` or `/sessions/:sessionId/decline`
* 
 * Should recieve response:
 ```
 {
   "status": 200,
    "data":
        {
        sessionId:1
        mentorId:1
        menteeId:1
        questions:"a question"
        menteeEmail:"email"
        status:"accepted or declined"
            
        },
}
 ```
#### What are the relevant pivotal tracker stories?
[#168073889](https://www.pivotaltracker.com/story/show/168073889)
#### Screenshots (if appropriate) 

![accept-reject-passing](https://user-images.githubusercontent.com/45785786/63633901-43e4ca80-c658-11e9-9712-3b79109e9deb.png)
